### PR TITLE
Fix date errors

### DIFF
--- a/taskmasterexp/chatbot/assistant.py
+++ b/taskmasterexp/chatbot/assistant.py
@@ -4,6 +4,7 @@ from langchain.agents import AgentExecutor, create_openai_tools_agent
 from langchain.prompts.chat import ChatPromptTemplate, MessagesPlaceholder
 
 from taskmasterexp.auth.dependencies import CurrentUserWA, CurrentUserWS
+from taskmasterexp.helpers import get_current_time, get_weekday
 from taskmasterexp.schemas.tasks import Task
 from taskmasterexp.schemas.users import User
 from taskmasterexp.settings import DEMO_PHONE_NUMBERS
@@ -68,6 +69,7 @@ async def _get_chat_agent(user: User) -> AgentExecutor:
             "if the user says that it *will* or *should* do it, set a due date instead."
             "If you are not sure, ask for confirmation.",
         ),
+        ("system", f"Today is {get_weekday()}, {get_current_time()}"),
         ("system", email_message),
         MessagesPlaceholder(variable_name="history"),
         ("human", human_template),

--- a/taskmasterexp/chatbot/demo/assistant.py
+++ b/taskmasterexp/chatbot/demo/assistant.py
@@ -2,6 +2,8 @@ import logging
 
 from langchain.agents import AgentExecutor, create_openai_tools_agent
 from langchain.prompts.chat import ChatPromptTemplate, MessagesPlaceholder
+from langchain_core.tools import tool
+
 
 from taskmasterexp.schemas.users import User
 from taskmasterexp.settings import DEMO_TOPIC
@@ -12,6 +14,12 @@ logger = logging.getLogger(__name__)
 
 
 human_template = "{text}"
+
+
+@tool
+def demo_tool():
+    """A tool that does nothing, just a placeholder for the demo."""
+    return DEMO_TOPIC
 
 
 async def get_demo_chat_agent(user: User) -> AgentExecutor:
@@ -31,7 +39,7 @@ async def get_demo_chat_agent(user: User) -> AgentExecutor:
         MessagesPlaceholder(variable_name="agent_scratchpad"),
     ]
 
-    tools = []
+    tools = [demo_tool]
 
     chat_prompt = ChatPromptTemplate.from_messages(messages)
 

--- a/taskmasterexp/chatbot/demo/assistant.py
+++ b/taskmasterexp/chatbot/demo/assistant.py
@@ -4,7 +4,6 @@ from langchain.agents import AgentExecutor, create_openai_tools_agent
 from langchain.prompts.chat import ChatPromptTemplate, MessagesPlaceholder
 from langchain_core.tools import tool
 
-
 from taskmasterexp.schemas.users import User
 from taskmasterexp.settings import DEMO_TOPIC
 

--- a/taskmasterexp/chatbot/demo/assistant.py
+++ b/taskmasterexp/chatbot/demo/assistant.py
@@ -7,7 +7,6 @@ from taskmasterexp.schemas.users import User
 from taskmasterexp.settings import DEMO_TOPIC
 
 from ..client import get_chat_model
-from ..tools import get_current_time
 
 logger = logging.getLogger(__name__)
 
@@ -32,7 +31,7 @@ async def get_demo_chat_agent(user: User) -> AgentExecutor:
         MessagesPlaceholder(variable_name="agent_scratchpad"),
     ]
 
-    tools = [get_current_time]
+    tools = []
 
     chat_prompt = ChatPromptTemplate.from_messages(messages)
 

--- a/taskmasterexp/chatbot/tools.py
+++ b/taskmasterexp/chatbot/tools.py
@@ -13,7 +13,8 @@ logger = logging.getLogger(__name__)
 
 def _get_weekday() -> str:
     """Return the current weekday."""
-    return datetime.datetime.now().strftime("%A")
+    zone = ZoneInfo("America/Los_Angeles")
+    return datetime.datetime.now(tz=zone).strftime("%A")
 
 
 @tool

--- a/taskmasterexp/chatbot/tools.py
+++ b/taskmasterexp/chatbot/tools.py
@@ -1,7 +1,6 @@
 import datetime
 import logging
 from uuid import UUID
-from zoneinfo import ZoneInfo
 
 from langchain_core.tools import tool
 
@@ -9,19 +8,6 @@ from taskmasterexp.database.managers import TaskManager, UserManager
 from taskmasterexp.schemas.tasks import Task, TaskStatus
 
 logger = logging.getLogger(__name__)
-
-
-def _get_weekday() -> str:
-    """Return the current weekday."""
-    zone = ZoneInfo("America/Los_Angeles")
-    return datetime.datetime.now(tz=zone).strftime("%A")
-
-
-@tool
-def get_current_time() -> str:
-    """Return the current time in ISO format and the weekday."""
-    zone = ZoneInfo("America/Los_Angeles")
-    return datetime.datetime.now(tz=zone).isoformat() + " " + _get_weekday()
 
 
 @tool
@@ -217,7 +203,6 @@ async def associate_email_to_user(user_id: str, email: str):
 
 
 tools = [
-    get_current_time,
     get_pending_task_list,
     get_tasks_for_date,
     add_new_task,

--- a/taskmasterexp/helpers.py
+++ b/taskmasterexp/helpers.py
@@ -1,0 +1,14 @@
+import datetime
+from zoneinfo import ZoneInfo
+
+TZ = ZoneInfo("America/Los_Angeles")
+
+
+def get_weekday() -> str:
+    """Return the current weekday."""
+    return datetime.datetime.now(tz=TZ).strftime("%A")
+
+
+def get_current_time() -> str:
+    """Return the current time in ISO format."""
+    return datetime.datetime.now(tz=TZ).isoformat()

--- a/taskmasterexp/helpers.py
+++ b/taskmasterexp/helpers.py
@@ -1,7 +1,9 @@
 import datetime
 from zoneinfo import ZoneInfo
 
-TZ = ZoneInfo("America/Los_Angeles")
+from taskmasterexp.settings import TIMEZONE
+
+TZ = ZoneInfo(TIMEZONE)
 
 
 def get_weekday() -> str:

--- a/taskmasterexp/settings.py
+++ b/taskmasterexp/settings.py
@@ -32,3 +32,4 @@ DEMO_PHONE_NUMBERS = [
     phone.strip() for phone in os.getenv("DEMO_PHONE_NUMBERS", "").split(",")
 ]
 DEMO_TOPIC = os.getenv("DEMO_TOPIC", "economy")
+TIMEZONE = os.getenv("TIMEZONE", "America/Los_Angeles")

--- a/taskmasterexp/tests/tools/test_task_tools.py
+++ b/taskmasterexp/tests/tools/test_task_tools.py
@@ -4,13 +4,13 @@ from taskmasterexp.chatbot.tools import (
     add_new_task,
     complete_task,
     delete_task,
-    get_current_time,
     get_pending_task_list,
     get_tasks_for_date,
     modify_task,
     set_task_due_date,
 )
 from taskmasterexp.database.managers import TaskManager
+from taskmasterexp.helpers import get_current_time
 from taskmasterexp.schemas.tasks import TaskStatus
 
 
@@ -40,8 +40,7 @@ async def test_get_task_for_date(
     test_admin_user,
     due_date,
 ):
-    current_time = await get_current_time.ainvoke({})
-    today = current_time.split()[0]
+    today = get_current_time()
 
     with patch_task_manager:
         task_list = await get_tasks_for_date.ainvoke(


### PR DESCRIPTION
The bot guesses the date randomly from time to time. Add a permanent date instruction to avoid guessing.